### PR TITLE
Fixed path Android setup build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Click `<YourAppName>.xcodeproj` in the project navigator and go the `Build Setti
 
 Run `rnpm link react-native-lock` so your project is linked against your Android project 
 
-In your file `android/settings.gradle`, inside the `android` section add the following
+In your file `android/app/build.gradle`, inside the `android` section add the following
 
 ```gradle
 packagingOptions {


### PR DESCRIPTION
The docs said "In your file `android/settings.gradle`, inside the `android` section add the following".
It should be "In your file `android/app/build.gradle`, inside the `android` section add the following"