### PR TITLE
Update Podfile.template

### DIFF
--- a/Podfile.template
+++ b/Podfile.template
@@ -1,4 +1,20 @@
 
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'myproject' do
+  # Uncomment this line if you're using Swift or would like to use dynamic fram$
+  # use_frameworks!
+
+  # Pods for myproject
+
+  target 'myprojectTests' do
+    inherit! :search_paths
+    # Pods for testing
+  end
+
+end
+
 # Auth0 Lock
 
 pod 'Lock', '~> 1.26'


### PR DESCRIPTION
The current template for manual installation has no target.  If you do not specify a target, you will get errors like, "The dependency `Lock (~> 1.26)` is not used in any concrete target."