### PR TITLE
Enable login through Safari

### DIFF
--- a/ios/A0RNLock/A0LockReactModule.m
+++ b/ios/A0RNLock/A0LockReactModule.m
@@ -40,6 +40,11 @@
 #import <Lock-GooglePlus/A0GooglePlusAuthenticator.h>
 #endif
 
+#if __has_include(<Lock/A0SafariAuthenticator.h>)
+#define SAFARI_GOOGLE_OAUTH2_ENABLED 1
+#import <Lock/A0SafariAuthenticator.h>
+#endif
+
 @implementation A0LockReactModule
 
 RCT_EXPORT_MODULE(Auth0LockModule);
@@ -80,6 +85,13 @@ RCT_EXPORT_METHOD(nativeIntegrations:(NSDictionary *)integrations) {
             NSString *apiKey = values[@"api_key"];
             NSString *apiSecret = values[@"api_secret"];
             [authenticators addObject:[A0TwitterAuthenticator newAuthenticatorWithKey:apiKey andSecret:apiSecret]];
+        }
+#endif
+#ifdef SAFARI_GOOGLE_OAUTH2_ENABLED
+        if ([@"safari" isEqualToString:key]) {
+            NSString *connectionName = values[@"connection_name"];
+            BOOL useUniversalLink = values[@"use_universal_link"] != nil ? [values[@"use_universal_link"] boolValue] : YES;
+            [authenticators addObject:[[A0SafariAuthenticator alloc] initWithLock:lock connectionName:connectionName useUniversalLink:useUniversalLink]];
         }
 #endif
 #ifdef GOOGLE_PLUS_ENABLED

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -13,4 +13,5 @@ target 'A0RNLockCore' do
   pod 'Lock/Email'
   pod 'Lock/SMS'
   pod 'Lock/TouchID'
+  pod 'Lock/Safari'
 end


### PR DESCRIPTION
Hi, I tried to patch `react-native-lock` to use Safari authenticator from Lock, as discussed in #105, and this seems to work for me. Since it seems to be a hot issue, I've decided to share my endeavours with you.

This is very raw and I didn't have much chance to test it properly (also lots of weird stuff happened on the way), but I hope this lays the foundation for porting this functionality from Lock into `react-native-lock`.

In order to make this work (hopefully) in your application, you need to do several things first.

* pass new parameters to `Auth0Lock` constructor (along with `clientId` and `domain`):
```javascript
integrations: {
  safari: {
    connection_name: 'google-oauth2',
    use_universal_link: false, // this is optional, defaults to true, more info here: https://auth0.com/docs/clients/enable-universal-links
  },
}
```
* update your `Info.plist` as described here: https://github.com/auth0/Auth0.swift#web-based-auth-ios-only
* add `openUrl` handler in your `AppDelegate` as described here: https://github.com/auth0/Auth0.swift#web-based-auth-ios-only

  Here's my version in Objective-C:
```objectivec
#import <Lock/Lock.h>
#import "../../node_modules/react-native-lock/ios/A0RNLock/Core/A0LockReact.h" // I don't know a better way to do this

...

- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
{
  return [[[A0LockReact sharedInstance] lock] handleURL:url sourceApplication:sourceApplication];
}
```

I never had any experience with Objective-C before, so feel free to suggest any improvements.