### PR TITLE
clearer explanation for the ios configuration for using the native br…

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,13 +285,13 @@ And finally in the file `Info.plist` add the following entry
     <string>auth0</string>
     <key>CFBundleURLSchemes</key>
     <array>
-      <string>{Bundle Identifier}</string>
+      <string>{Replace this with Bundle Identifier}</string>
     </array>
   </dict>
 </array>
 ```
 
-Where the Bundle identifier can be found in the same file under the key `CFBundleIdentifier` like
+Where the Bundle identifier can be found and has to be replaced by the same value in the same file under the key `CFBundleIdentifier` like
 
 ```xml
 <key>CFBundleIdentifier</key>


### PR DESCRIPTION
clearer explanation for the ios configuration for using the native browser to authenticate

I am not really familiar with plist-files and so are probably also some other users of auth0, who want to use it with react-native, so i did not know i had to replace `{Bundle Identifier}` and wasted some time. I hope this fix will make it a bit clearer for other users.